### PR TITLE
Add routes for each component type

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -24,7 +24,8 @@
         "react-player": "^2.16.0",
         "tailwind-merge": "^2.2.1",
         "tailwind-variants": "^1.0.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.7.0",
@@ -15999,6 +16000,14 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/sort-css-media-queries": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.2.0.tgz",
@@ -17151,11 +17160,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/website/package.json
+++ b/website/package.json
@@ -32,7 +32,8 @@
     "react-player": "^2.16.0",
     "tailwind-merge": "^2.2.1",
     "tailwind-variants": "^1.0.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.7.0",

--- a/website/src/components/ccc/Component/index.tsx
+++ b/website/src/components/ccc/Component/index.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import { Card, CardContent, CardHeader, CardTitle } from "../../ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../ui/table";
+import { User } from "../User";
+import { ComponentPageData } from "@site/src/types/ccc";
+
+export default function CCCReleaseTemplate({ pageData }: { pageData: ComponentPageData }) {
+  const { metadata } = pageData.component.releases[0];
+
+  return (
+    <Layout title={metadata.title}>
+      <main className="container margin-vert--lg space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>{metadata.title}</CardTitle>
+            <p className="text-muted-foreground">{metadata.description}</p>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Version</TableHead>
+                  <TableHead>Release Manager</TableHead>
+                  <TableHead>Authors</TableHead>
+                  <TableHead>Controls</TableHead>
+                  <TableHead>Threats</TableHead>
+                  <TableHead>Features</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {pageData.component.releases.map((release) => (
+                  <TableRow key={release.metadata.id}>
+                    <TableCell>
+                      <Link to={release.slug} className="text-blue-600  hover:text-blue-800 hover:underline">
+                        {release.metadata.release_details[0].version}
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      <User name={release.metadata.release_details[0].release_manager.name} githubId={release.metadata.release_details[0].release_manager.github_id} company={release.metadata.release_details[0].release_manager.company} avatarUrl={`https://github.com/${release.metadata.release_details[0].release_manager.github_id}.png`} />
+                    </TableCell>
+                    <TableCell>{release.metadata.release_details[0].contributors.length}</TableCell>
+                    <TableCell>{release.controls.length}</TableCell>
+                    <TableCell>{release.threats.length}</TableCell>
+                    <TableCell>{release.features.length}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </main>
+    </Layout>
+  );
+}

--- a/website/src/components/ccc/Home/index.tsx
+++ b/website/src/components/ccc/Home/index.tsx
@@ -192,7 +192,7 @@ export default function CCCHomeTemplate({ pageData }: { pageData: HomePageData }
       title: component.title,
       numberOfReleases: component.releases.length,
       latestVersion: latestRelease.version,
-      slug: component.releases[0].slug,
+      slug: component.slug,
     };
   });
 

--- a/website/src/plugin/ccc-pages/PageCreator.ts
+++ b/website/src/plugin/ccc-pages/PageCreator.ts
@@ -1,0 +1,17 @@
+import { RouteConfig } from "@docusaurus/types";
+import {v4 as uuidv4} from 'uuid';
+
+export class PageCreator {
+    private readonly createData: (name: string, data: string | object) => Promise<string>;
+    private readonly addRoute: (config: RouteConfig) => void;
+
+    constructor(createData, addRoute) {
+        this.createData = createData;
+        this.addRoute = addRoute;
+    }
+
+    async createPage(pageData: any, path: string, component: string) {
+        const jsonPath = await this.createData(uuidv4() + '.json', JSON.stringify(pageData));
+        this.addRoute({path, component, modules: { pageData: jsonPath }, exact: true});
+    }
+}

--- a/website/src/plugin/ccc-pages/index.ts
+++ b/website/src/plugin/ccc-pages/index.ts
@@ -51,7 +51,6 @@ function parseControl(control: any, slug: string): Control {
     };
 }
 
-
 function createControlPageData(controlYaml: any, release: Release, parsed: CCCReleaseYaml): ControlPageData {
     const control = parseControl(controlYaml, release.slug);
 
@@ -111,16 +110,11 @@ export default function pluginCCCPages(_: LoadContext): Plugin<PluginContent> {
             const dataDir = path.resolve(__dirname, '../../data/ccc-releases');
             const files = fs.readdirSync(dataDir).filter((f) => f.endsWith('.yaml'));
 
-            const releases: CCCReleaseYaml[] = [];
-
-            for (const file of files) {
+            return files.map((file) => {
                 const filePath = path.join(dataDir, file);
                 const raw = fs.readFileSync(filePath, 'utf8');
-                const parsed = yaml.load(raw) as CCCReleaseYaml;
-                releases.push(parsed);
-            }
-
-            return releases;
+                return yaml.load(raw) as CCCReleaseYaml;
+            });
         },
 
         async contentLoaded({ actions, content }) {

--- a/website/src/plugin/ccc-pages/index.ts
+++ b/website/src/plugin/ccc-pages/index.ts
@@ -51,7 +51,7 @@ function parseControl(control: any, slug: string): Control {
     };
 }
 
-function createControlPageData(controlYaml: any, release: Release, parsed: CCCReleaseYaml): ControlPageData {
+function createControlPageData(controlYaml: any, release: Release): ControlPageData {
     const control = parseControl(controlYaml, release.slug);
 
     const relatedThreats = controlYaml.threats?.map(threatId => release.threats.find(t => t.id === threatId)
@@ -62,12 +62,12 @@ function createControlPageData(controlYaml: any, release: Release, parsed: CCCRe
             ...control,
             related_threats: relatedThreats,
         },
-        releaseTitle: parsed.metadata.title,
+        releaseTitle: release.metadata.title,
         releaseSlug: release.slug,
     };
 }
 
-function createFeaturePageData(featureYaml: any, release: Release, parsed: CCCReleaseYaml): FeaturePageData {
+function createFeaturePageData(featureYaml: any, release: Release): FeaturePageData {
     const feature = parseFeature(featureYaml, release.slug);
 
     // Find all threats that reference this feature
@@ -78,12 +78,12 @@ function createFeaturePageData(featureYaml: any, release: Release, parsed: CCCRe
             ...feature,
             related_threats: relatedThreats
         },
-        releaseTitle: parsed.metadata.title,
+        releaseTitle: release.metadata.title,
         releaseSlug: release.slug,
     };
 }
 
-function createThreatPageData(threatYaml: any, release: Release, parsed: CCCReleaseYaml): ThreatPageData {
+function createThreatPageData(threatYaml: any, release: Release): ThreatPageData {
     const threat = parseThreat(threatYaml, release.slug);
 
     const relatedControls = release.controls.filter(control => control.threats.includes(threat.id))
@@ -97,7 +97,7 @@ function createThreatPageData(threatYaml: any, release: Release, parsed: CCCRele
             related_controls: relatedControls,
             related_features: relatedFeatures
         },
-        releaseTitle: parsed.metadata.title,
+        releaseTitle: release.metadata.title,
         releaseSlug: release.slug,
     };
 }
@@ -146,17 +146,17 @@ export default function pluginCCCPages(_: LoadContext): Plugin<PluginContent> {
                 await pageCreator.createPage(cccReleasePageData, release.slug, '@site/src/components/ccc/Release/index.tsx');
 
                 for (const controlYaml of parsed.controls) {
-                    const pageData: ControlPageData = createControlPageData(controlYaml, release, parsed);
+                    const pageData: ControlPageData = createControlPageData(controlYaml, release);
                     await pageCreator.createPage(pageData, `${pageData.control.slug}`, '@site/src/components/ccc/Control/index.tsx');
                 }
 
                 for (const featureYaml of parsed.features || []) {
-                    const pageData: FeaturePageData = createFeaturePageData(featureYaml, release, parsed);
+                    const pageData: FeaturePageData = createFeaturePageData(featureYaml, release);
                     await pageCreator.createPage(pageData, `${pageData.feature.slug}`, '@site/src/components/ccc/Feature/index.tsx');
                 }
 
                 for (const threatYaml of parsed.threats || []) {
-                    const pageData: ThreatPageData = createThreatPageData(threatYaml, release, parsed);
+                    const pageData: ThreatPageData = createThreatPageData(threatYaml, release);
                     pageCreator.createPage(pageData, `${pageData.threat.slug}`, '@site/src/components/ccc/Threat/index.tsx');
                 }
             }

--- a/website/src/types/ccc.ts
+++ b/website/src/types/ccc.ts
@@ -84,6 +84,7 @@ export interface Control {
 export interface Component {
     title: string;
     releases: Release[];
+    slug?: string;
 }
 
 
@@ -108,6 +109,10 @@ export interface ControlPageData extends PageData {
 
 export interface ReleasePageData extends PageData {
     release: Release;
+}
+
+export interface ComponentPageData extends PageData {
+    component: Component;
 }
 
 export interface HomePageData {


### PR DESCRIPTION
This adds a route for each component type e.g. `/ccc/CCC.RDMS`, with a table of releases on it.

Some refactoring has also been done around page creation to reduce duplicated code.

![image](https://github.com/user-attachments/assets/0a05dd47-0087-4349-aa08-6eab38c0bdcb)